### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,37 +1,22 @@
 {
   "npmScope": "test-13-latest",
-  "affected": {
-    "defaultBase": "main"
-  },
-  "cli": {
-    "defaultCollection": "@nrwl/workspace"
-  },
+  "affected": { "defaultBase": "main" },
+  "cli": { "defaultCollection": "@nrwl/workspace" },
   "implicitDependencies": {
-    "package.json": {
-      "dependencies": "*",
-      "devDependencies": "*"
-    },
+    "package.json": { "dependencies": "*", "devDependencies": "*" },
     ".eslintrc.json": "*"
   },
   "tasksRunnerOptions": {
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {
-        "cacheableOperations": [
-          "build",
-          "lint",
-          "test",
-          "e2e"
-        ]
+        "cacheableOperations": ["build", "lint", "test", "e2e"],
+        "accessToken": "ZjRhZDNkMTMtZjU1Yy00ODA1LWFlOTQtNjIyMDUxNTMyNTFmfHJlYWQtd3JpdGU=",
+        "nxCloudUrl": "https://staging.nx.app"
       }
     }
   },
   "targetDependencies": {
-    "build": [
-      {
-        "target": "build",
-        "projects": "dependencies"
-      }
-    ]
+    "build": [{ "target": "build", "projects": "dependencies" }]
   }
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 
    
This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.

You can access your Nx Cloud workspace by going to 
https://staging.nx.app/orgs/66d07e5fa337e3bcff9f291f/workspaces/66d07e63a337e3bcff9f2921

**Note:** This commit attempts to maintain formatting of the nx.json, however you may need to correct formatting by running an nx format command and committing the changes.